### PR TITLE
fixes of usage of bfd to work with binutils>=2.28

### DIFF
--- a/src/addr2line.c
+++ b/src/addr2line.c
@@ -21,6 +21,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include "config.h"
+
 #define _GNU_SOURCE
 #include <sys/types.h>
 #include <stdio.h>
@@ -44,12 +46,9 @@
 static rb_red_blk_tree* range_map;
 static rb_red_blk_tree* frame_map;
 
-static void addr2LineErrorHandler(char const* fmt, ...)
+static void addr2LineErrorHandler(char const* fmt, va_list ap)
 {
-  va_list ap;
-  va_start(ap, fmt);
   vfprintf(stderr, fmt, ap);
-  va_end(ap);
 }
 
 static void addr2LinePrintErr(char const* string)

--- a/src/hello.cc
+++ b/src/hello.cc
@@ -5,6 +5,7 @@
 #include <cstdio>
 
 extern "C" {
+#include "config.h"
 #include "addr2line.h"
 }
 

--- a/src/memleak.c
+++ b/src/memleak.c
@@ -40,6 +40,7 @@
 #include <sys/un.h>
 #include <errno.h>
 
+#include "config.h"
 #include "addr2line.h"
 #include "sort.h"
 


### PR DESCRIPTION
It seems the API of bfd was slightly changed as of binutils 2.28. This patch makes the project to compile again.