### PR TITLE
Support for ARM target

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,8 @@ AC_CHECK_LIB(readline, readline, [LIBREADLINE=-lreadline])
 # Detect bfd_error_handler_type style.
 CW_TYPE_BFD_ERROR_HANDLER_TYPE
 
+AC_DEFINE_UNQUOTED([TARGET], ["$target_alias"], [The target architecture (must match BFD's target)])
+
 AC_SUBST(LIBBFD)
 AC_SUBST(LIBREADLINE)
 

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ AC_CONFIG_FILES([libmemleak.pc])
 AC_CHECK_LIB(bfd, bfd_init, [LIBBFD=-lbfd])
 AC_CHECK_LIB(readline, readline, [LIBREADLINE=-lreadline])
 
+AC_CHECK_SIZEOF([time_t])
+
 # Detect bfd_error_handler_type style.
 CW_TYPE_BFD_ERROR_HANDLER_TYPE
 

--- a/src/addr2line.c
+++ b/src/addr2line.c
@@ -285,14 +285,14 @@ static void find_address_in_section(bfd* abfd, asection* section, void* data)
   if (x->found)
     return;
 
-  if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
+  if ((bfd_section_flags(section) & SEC_ALLOC) == 0)
     return;
 
-  vma = bfd_get_section_vma(abfd, section);
+  vma = bfd_section_vma(section);
   if (x->pc < vma)
     return;
 
-  size = bfd_get_section_size(section);
+  size = bfd_section_size(section);
   if (x->pc >= vma + size)
     return;
 

--- a/src/addr2line.c
+++ b/src/addr2line.c
@@ -35,7 +35,8 @@
 #include "addr2line.h"
 #include "rb_tree/red_black_tree.h"
 
-#define TARGET "x86_64-pc-linux-gnu"
+// arnaudviala: the TARGET is defined in config.h (by ./configure script)
+// #define TARGET "x86_64-pc-linux-gnu"
 
 #define false 0
 #define true 1

--- a/src/hello.cc
+++ b/src/hello.cc
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 #include <deque>
 #include <cstdio>
+#include <string.h>	// for memset()
 
 extern "C" {
 #include "addr2line.h"
@@ -126,6 +127,7 @@ void do_work(bool leak)
   int32_t rvalue;
   char rstatebuf[256];
 
+  memset(&rdata, 0, sizeof(rdata)); // fix for a bug in initstate_r() impl
   initstate_r(0x1234aabc, rstatebuf, sizeof(rstatebuf), &rdata);
 
   for (int i = 0; i < 1000000000; ++i)

--- a/src/include/addr2line.h
+++ b/src/include/addr2line.h
@@ -26,6 +26,18 @@
 #endif
 #include <bfd.h>        // binutils 2.28 wants a config.h to be included first.
 
+// Older versions of binutils (< 2.34) are using macros to access members
+// of 'asection' structure. Since 2.34, it has been replace by static inline functions.
+#if defined(bfd_get_section_flags)
+// we must undefine old macros using a different prototype
+#undef bfd_section_size
+#undef bfd_section_vma
+#undef bfd_section_flags
+static inline bfd_size_type bfd_section_size(const asection *sec) { return sec->size; }
+static inline bfd_vma       bfd_section_vma(const asection *sec) { return sec->vma; }
+static inline flagword      bfd_section_flags(const asection *sec) { return sec->flags; }
+#endif
+
 #ifndef bool
 //! @brief A boolean type.
 #define bool int

--- a/src/memleak.c
+++ b/src/memleak.c
@@ -747,7 +747,9 @@ time_t interval_class(time_t interval)
   v |= v >> 4;
   v |= v >> 8;
   v |= v >> 16;
+#if SIZEOF_TIME_T == 8
   v |= v >> 32;
+#endif
   ++v;
   return v;
 }


### PR DESCRIPTION
Hi Carlowood,

First, thanks a lot for this libmemleak project. I started looking at it in 2019/2020 as I was looking for a tool to monitor memory leaks. Your approach of starting at some point in time once the program is up and running is particularly interesting. The second approach I was looking for was the ability to debug an already built binary (which the use of `LD_PRELOAD=...` permits).

I'm working on embedded systems on various architectures. On some systems, we could use valgrind or gcc's AddressSanitizer but some smaller systems can't handle such tools (valgrind has a massive impact on the runtime). Your library is much more lightweight and that makes it a very interesting tool.

So far, I used libmemleak on the following architecture: `arm/cortexa7hf` and `arm/aarch64`.

In this Pull-Request, I'm proposing the following changes to support ARM architectures:
```
1. have a dynamic `#define TARGET ...` which can be given as a `./configure --target=` argument
    (it now integrates nicely with Yocto)

2. let `configure[.ac]` determine the size of `time_t`
    I've been building for 32bits and 64bits architectures, the size of time_t is different

3. fix a crash in hello.cc example (with glibc-2.25 on "arm/cortexa7hf")
    see https://sourceware.org/bugzilla/show_bug.cgi?id=3662

4. update to binutils-2.34 API for bfd_section_xxx() functions
    one of the systems has a "newer" binutils which get rid of the bfd_get_section_xxx() macros
    my modification is designed to be backward compatible (I'm redefining the newer functions if they don't exist)
```

Feel free to ask any questions if you have any or make any comments. I can rework some of those changes if necessary.

Thanks for having created and shared this library,
Arnaud
